### PR TITLE
Specify minimum nodejs version (8.11 is current LTS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
       "theme": "https://github.com/10up/theme-scaffold",
       "plugin": "https://github.com/10up/plugin-scaffold"
     }
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": "~8.11"
   }
 }


### PR DESCRIPTION
@timwright12 does this node version work for you? 8.11.2 is the current LTS version.