### PR TITLE
Add ThemeScaffold and PluginScaffold to the renaming.

### DIFF
--- a/10upScaffold.js
+++ b/10upScaffold.js
@@ -64,7 +64,7 @@ const directoriesToRemove = ['.git'];
 // Objects of text strings to find and replace
 const textToReplace = [
 	{
-		from: /TenUpScaffold/g,
+		from: /TenUpScaffold|PluginScaffold|ThemeScaffold/g,
 		to: nameCamelCase
 	},
 	{


### PR DESCRIPTION
Both the theme-scaffold and plugin-scaffold have @package name in the PHP files which are not being renamed.