### PR TITLE
Change language file name to hyphenated case.

### DIFF
--- a/10upScaffold.js
+++ b/10upScaffold.js
@@ -96,8 +96,8 @@ const directoriesToRename = [
 		to: directoryName
 	},
 	{
-		from: 'languages/TenUpScaffold.pot',
-		to: 'languages/' + nameCamelCase + '.pot'
+		from: 'languages/ten-up-scaffold.pot',
+		to: 'languages/' + directoryName + '.pot'
 	}
 ];
 


### PR DESCRIPTION
Unless there is some specific advantage to having a POT file as camelCase, I recommend using hyphenated case for all file names within the plugins and themes.